### PR TITLE
Corrected link

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -2,6 +2,6 @@
 title = "Home"
 +++
 
-We are a collaborative, interdisciplinary group at [Saint Louis University](www.slu.edu) focused on building researchers' data science skills using open source software. We currently host seminars focused on the programming language `R`. 
+We are a collaborative, interdisciplinary group at [Saint Louis University](https://www.slu.edu) focused on building researchers' data science skills using open source software. We currently host seminars focused on the programming language `R`. 
 
 The DSS is organized by [Christina Garcia](mailto:garciacm@slu.edu), [Kelly Lovejoy](mailto:lovejoykg@slu.edu), and [Chris Prener](mailto:prenercg@slu.edu).


### PR DESCRIPTION
Without a protocol, www.slu.edu attempted to link internally.